### PR TITLE
Add screenshot extensions for the IScreen interface.

### DIFF
--- a/Sample/DISample/Tests.cs
+++ b/Sample/DISample/Tests.cs
@@ -32,7 +32,8 @@ namespace ScreenObjectXUI.Samples.DISample
 		public void Login()
 		{
 			app.Screen<ILoginScreen>()
-			   .Login("Test", "Test");
+			   .Login("Test", "Test")
+			   .Screenshot("Login");
 		}
 	}
 }

--- a/ScreenObjectXUI/Utils/ScreenExtensions.cs
+++ b/ScreenObjectXUI/Utils/ScreenExtensions.cs
@@ -28,5 +28,15 @@ namespace ScreenObjectXUI.Utils
 				throw new Exception($"The {typeof(TScreen)} screen was not found.");
 			}
 		}
+
+		public static void Screenshot(this IScreen screen, string title)
+		{
+			screen.App.Screenshot(title);
+		}
+
+		public static void Screenshot(this IScreen screen, string format, params object[] args)
+		{
+			screen.App.Screenshot(format, args);
+		}
 	}
 }


### PR DESCRIPTION
This allows for better fluent support. You can now write tests like this:

```
app.Screen<ILoginScreen>()
      .Login("Test", "Test")
      .Screenshot("Login");
```

instead of:
```
app.Screen<ILoginScreen>()
      .Login("Test", "Test")
      .App.Screenshot("Login");
```